### PR TITLE
chore: use pinocchio 11.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pinocchio-secp256r1-instruction"
 authors = ["Dean Little <@deanmlittle>"]
 description = "Pinocchio helper functions to deserialize Secp256r1 instructions"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ default = []
 perf = []
 
 [dependencies]
-pinocchio = "^0.8.0"
+pinocchio = "^0.11.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,12 @@
 #![no_std]
 
-use pinocchio::{
-    program_error::ProgramError, pubkey::Pubkey, sysvars::instructions::IntrospectedInstruction,
-};
+use pinocchio::{error::ProgramError, sysvars::instructions::IntrospectedInstruction, Address};
 
 // Secp256r1SigVerify1111111111111111111111111
-pub const SECP256R1_PROGRAM_ID: Pubkey = [
+pub const SECP256R1_PROGRAM_ID: Address = Address::new_from_array([
     0x06, 0x92, 0x0d, 0xec, 0x2f, 0xea, 0x71, 0xb5, 0xb7, 0x23, 0x81, 0x4d, 0x74, 0x2d, 0xa9, 0x03,
     0x1c, 0x83, 0xe7, 0x5f, 0xdb, 0x79, 0x5d, 0x56, 0x8e, 0x75, 0x47, 0x80, 0x20, 0x00, 0x00, 0x00,
-];
+]);
 pub const SECP256R1_SIGNATURE_LENGTH: usize = 64;
 pub const SECP256R1_COMPRESSED_PUBKEY_LENGTH: usize = 33;
 


### PR DESCRIPTION
closes https://github.com/deanmlittle/pinocchio-secp256r1-instruction/issues/2

Changes

- [x]  bump pinocchio version to 0.11.2
- [x]  use `Address` instead of pubkey
- [x]  use the new `ProgramError` import
- [x]  verified test passing
- [x] bump version for this crate